### PR TITLE
Add Support for Multiple Configurable Sidekiq Processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,37 @@ bundle exec kuby -e production push
 bundle exec kuby -e production deploy
 ```
 
+## Advanced Configuration
+
+If you have a more complex setup for Sidekiq you can specify the processes you need to create. The options method allow you to
+provide command line arguments to Sidekiq in order to either specify a non-default `sidekiq.yml` file or queues for a process to
+run. The process name is required.
+
+```ruby
+require 'kuby/sidekiq'
+
+Kuby.define(:production) do
+  kubernetes do
+
+    add_plugin(:sidekiq) do
+      replicas 2  # sets the default number of replicas for each process
+
+
+      process('default') # sidekiq uses sidekiq.yml by default and has 2 replicas
+
+      process('slow_process') do
+        options ['-C', 'config/slow_sidekiq.yml']
+        replicas 4 # override default number of replicas
+      end
+
+      process('queue_processor') do
+        options ['-q', 'critical', '-q', 'less_critical']
+      end
+    end
+  end
+end
+```
+
 ## License
 
 Licensed under the MIT license. See LICENSE for details.

--- a/lib/kuby/sidekiq/plugin.rb
+++ b/lib/kuby/sidekiq/plugin.rb
@@ -24,8 +24,8 @@ module Kuby
       end
 
       def after_configuration
-        if processes.nil? || processes.empty?
-          self.processes = [SidekiqProcess.new(plugin: self, default_replicas: replicas)]
+        if processes.empty?
+          processes << SidekiqProcess.new(plugin: self, default_replicas: replicas)
         end
 
         environment.kubernetes.add_plugin(:redis) do

--- a/lib/kuby/sidekiq/plugin.rb
+++ b/lib/kuby/sidekiq/plugin.rb
@@ -89,7 +89,6 @@ module Kuby
       end
 
       def process(name, &block)
-        self.processes ||= []
         SidekiqProcess.new(name: name, plugin: self, default_replicas: replicas).tap do |process|
           process.instance_eval(&block) if block
           processes << process

--- a/lib/kuby/sidekiq/plugin.rb
+++ b/lib/kuby/sidekiq/plugin.rb
@@ -88,7 +88,10 @@ module Kuby
 
       def process(name, &block)
         self.processes ||= []
-        process = SidekiqProcess.new(name: name, plugin: self, default_replicas: replicas)
+        SidekiqProcess.new(name: name, plugin: self, default_replicas: replicas).tap do |process|
+          process.instance_eval(&block) if block
+          processes << process
+        end
 
         process.instance_eval(&block) if block
         self.processes << process

--- a/lib/kuby/sidekiq/plugin.rb
+++ b/lib/kuby/sidekiq/plugin.rb
@@ -9,11 +9,11 @@ module Kuby
 
       ROLE = 'worker'.freeze
 
+      value_field :replicas, default: 1
+
       def processes
         @processes ||= []
       end
-
-      value_field :replicas, default: 1
 
       def connection_params
         redis_instance.connection_params
@@ -93,9 +93,6 @@ module Kuby
           process.instance_eval(&block) if block
           processes << process
         end
-
-        process.instance_eval(&block) if block
-        self.processes << process
       end
 
       def redis_instance

--- a/lib/kuby/sidekiq/plugin.rb
+++ b/lib/kuby/sidekiq/plugin.rb
@@ -1,5 +1,6 @@
 require 'securerandom'
 require 'kuby/redis'
+require_relative 'sidekiq_process'
 
 module Kuby
   module Sidekiq
@@ -7,6 +8,8 @@ module Kuby
       extend ::KubeDSL::ValueFields
 
       ROLE = 'worker'.freeze
+
+      attr_accessor :processes
 
       value_field :replicas, default: 1
 
@@ -19,6 +22,10 @@ module Kuby
       end
 
       def after_configuration
+        if processes.nil? || processes.empty?
+          self.processes = [SidekiqProcess.new(plugin: self, default_replicas: replicas)]
+        end
+
         environment.kubernetes.add_plugin(:redis) do
           instance :sidekiq do
             custom_config (custom_config || []).concat(['maxmemory-policy noeviction'])
@@ -27,24 +34,28 @@ module Kuby
 
         return unless rails_app
 
-        deployment.spec.template.spec.container(:worker).merge!(
-          rails_app.deployment.spec.template.spec.container(:web), fields: [:env_from]
-        )
+        processes.each do |process|
+          process.deployment.spec.template.spec.container(:worker).merge!(
+            rails_app.deployment.spec.template.spec.container(:web), fields: [:env_from]
+          )
 
-        if rails_app.manage_database? && database = Kuby::Plugins::RailsApp::Database.get(rails_app)
-          database.plugin.configure_pod_spec(deployment.spec.template.spec)
+          if rails_app.manage_database? && database = Kuby::Plugins::RailsApp::Database.get(rails_app)
+            database.plugin.configure_pod_spec(process.deployment.spec.template.spec)
+          end
         end
       end
 
       def before_deploy(manifest)
         image_with_tag = "#{docker.image.image_url}:#{kubernetes.tag || Kuby::Docker::LATEST_TAG}"
 
-        deployment do
-          spec do
-            template do
-              spec do
-                container(:worker) do
-                  image image_with_tag
+        processes.each do |process|
+          process.deployment do
+            spec do
+              template do
+                spec do
+                  container(:worker) do
+                    image image_with_tag
+                  end
                 end
               end
             end
@@ -53,10 +64,7 @@ module Kuby
       end
 
       def resources
-        @resources ||= [
-          service_account,
-          deployment
-        ]
+        @resources ||= [service_account, *processes.map(&:deployment)]
       end
 
       def service_account(&block)
@@ -78,67 +86,12 @@ module Kuby
         @service_account
       end
 
-      def deployment(&block)
-        context = self
+      def process(name, &block)
+        self.processes ||= []
+        process = SidekiqProcess.new(name: name, plugin: self, default_replicas: replicas)
 
-        @deployment ||= KubeDSL.deployment do
-          metadata do
-            name "#{context.selector_app}-sidekiq-#{ROLE}"
-            namespace context.namespace.metadata.name
-
-            labels do
-              add :app, context.selector_app
-              add :role, ROLE
-            end
-          end
-
-          spec do
-            replicas context.replicas
-
-            selector do
-              match_labels do
-                add :app, context.selector_app
-                add :role, ROLE
-              end
-            end
-
-            strategy do
-              type 'RollingUpdate'
-
-              rolling_update do
-                max_surge '25%'
-                max_unavailable 0
-              end
-            end
-
-            template do
-              metadata do
-                labels do
-                  add :app, context.selector_app
-                  add :role, ROLE
-                end
-              end
-
-              spec do
-                container(:worker) do
-                  name "#{context.selector_app}-sidekiq-#{ROLE}"
-                  image_pull_policy 'IfNotPresent'
-                  command %w(bundle exec sidekiq)
-                end
-
-                image_pull_secret do
-                  name context.kubernetes.registry_secret.metadata.name
-                end
-
-                restart_policy 'Always'
-                service_account_name context.service_account.metadata.name
-              end
-            end
-          end
-        end
-
-        @deployment.instance_eval(&block) if block
-        @deployment
+        process.instance_eval(&block) if block
+        self.processes << process
       end
 
       def redis_instance

--- a/lib/kuby/sidekiq/plugin.rb
+++ b/lib/kuby/sidekiq/plugin.rb
@@ -9,7 +9,9 @@ module Kuby
 
       ROLE = 'worker'.freeze
 
-      attr_accessor :processes
+      def processes
+        @processes ||= []
+      end
 
       value_field :replicas, default: 1
 

--- a/lib/kuby/sidekiq/sidekiq_process.rb
+++ b/lib/kuby/sidekiq/sidekiq_process.rb
@@ -1,0 +1,89 @@
+require 'securerandom'
+
+module Kuby
+  module Sidekiq
+    # This class creates a deployment for a Sikekiq Process. A process is a single instance
+    # of Sidekiq. Each instance can be provided command line options to specify concurrency,
+    # config files or queues.
+    # https://github.com/sidekiq/sidekiq/wiki/Best-Practices#4-use-precise-terminology
+    class SidekiqProcess
+      extend ::KubeDSL::ValueFields
+
+      ROLE='worker'
+
+      attr_reader :plugin, :name, :default_replicas
+
+      value_field :replicas, default: nil
+      value_field :options, default: []
+
+      def initialize(name: 'default', plugin:, default_replicas:)
+        @name = name
+        @plugin = plugin
+        @default_replicas = default_replicas
+      end
+
+      def deployment(&block)
+        context = self
+
+        @deployment ||= KubeDSL.deployment do
+          metadata do
+            name "#{context.plugin.selector_app}-sidekiq-#{ROLE}-#{context.name}"
+            namespace context.plugin.namespace.metadata.name
+
+            labels do
+              add :app, context.plugin.selector_app
+              add :role, ROLE
+            end
+          end
+
+          spec do
+            replicas (context.replicas || context.default_replicas)
+
+            selector do
+              match_labels do
+                add :app, context.plugin.selector_app
+                add :role, ROLE
+              end
+            end
+
+            strategy do
+              type 'RollingUpdate'
+
+              rolling_update do
+                max_surge '25%'
+                max_unavailable 0
+              end
+            end
+
+            template do
+              metadata do
+                labels do
+                  add :app, context.plugin.selector_app
+                  add :role, ROLE
+                end
+              end
+
+              spec do
+                container(:worker) do
+                  name "#{context.plugin.selector_app}-sidekiq-#{ROLE}-#{context.name}"
+                  image_pull_policy 'IfNotPresent'
+                  command ['bundle', 'exec', 'sidekiq', *context.options]
+                end
+
+                image_pull_secret do
+                  name context.plugin.kubernetes.registry_secret.metadata.name
+                end
+
+                restart_policy 'Always'
+                service_account_name context.plugin.service_account.metadata.name
+              end
+            end
+          end
+        end
+
+        @deployment.instance_eval(&block) if block
+        @deployment
+      end
+    end
+  end
+end

--- a/lib/kuby/sidekiq/sidekiq_process.rb
+++ b/lib/kuby/sidekiq/sidekiq_process.rb
@@ -2,7 +2,7 @@ require 'securerandom'
 
 module Kuby
   module Sidekiq
-    # This class creates a deployment for a Sikekiq Process. A process is a single instance
+    # This class creates a deployment for a Sidekiq Process. A process is a single instance
     # of Sidekiq. Each instance can be provided command line options to specify concurrency,
     # config files or queues.
     # https://github.com/sidekiq/sidekiq/wiki/Best-Practices#4-use-precise-terminology


### PR DESCRIPTION
This PR adds support for having multiple Sidekiq deployments with their own configured Sidekiq process. 

Usage

Works with the old interface:

```ruby
require 'kuby/sidekiq'
Kuby.define(:production) do
  kubernetes do
    add_plugin(:sidekiq) do
      replicas 2  # run two workers
    end
  end
end
```

This creates a Sidekiq deployment that is named `app-name-sidekiq-worker-default` with two replicas. 

To specify a more complex Sidekiq configuration:

```ruby
require 'kuby/sidekiq'
Kuby.define(:production) do
  kubernetes do
    add_plugin(:sidekiq) do
      replicas 2  # sets the default number of replicas for each process
      process('default') # sidekiq uses sidekiq.yml by default and has 2 replicas
      process('slow_process') do
        options ['-C', 'config/slow_sidekiq.yml']
        replicas 4 # override default number of replicas
      end
      process('queue_processor') do
        options ['-q', 'critical', '-q', 'less_critical']
      end
    end
  end
end
```

To accomplish this I've introduced a `SidekiqProcess` class that creates a deployment for each `process` in the kuby file. By default if no processes are defined then a default `SidekiqProcess` is created using the top level replicas value. 

I'm open to changing any naming here. I've tried to stick with the Sidekiq best practices for naming but I'm aware that some of this naming could be confusing with the `Process` module. 