### PR TITLE
Ensure Sidekiq is Terminated Gracefully

### DIFF
--- a/lib/kuby/sidekiq/sidekiq_process.rb
+++ b/lib/kuby/sidekiq/sidekiq_process.rb
@@ -67,7 +67,8 @@ module Kuby
                 container(:worker) do
                   name "#{context.plugin.selector_app}-sidekiq-#{ROLE}-#{context.name}"
                   image_pull_policy 'IfNotPresent'
-                  command ['bundle', 'exec', 'sidekiq', *context.options]
+                  command ['bundle', 'exec', 'sidekiq']
+                  args context.options
                 end
 
                 image_pull_secret do


### PR DESCRIPTION
We were running into an issue where our Sidekiq processes were not being evicted gracefully.

After some investigation it seems that by passing all the arguments as part of the command the `TERM` signal isn't being received by the Sidekiq process.

This guide on the Sidekiq Wiki explains the details of the issue pretty well:
https://github.com/sidekiq/sidekiq/wiki/Kubernetes

This PR separates the command from the arguments sent to Sidekiq.